### PR TITLE
Update API domain to api.netatmo.com

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	baseURL   = "https://api.netatmo.net/"
+	baseURL   = "https://api.netatmo.com/"
 	authURL   = baseURL + "oauth2/authorize"
 	tokenURL  = baseURL + "oauth2/token"
 	deviceURL = baseURL + "/api/getstationsdata"


### PR DESCRIPTION
> Important:
> We will be retiring the domain api.netatmo.net and consolidating all API traffic under the existing domain api.netatmo.com on September 8, 2025.
> Update your applications to use api.netatmo.com exclusively before the above date. The structure and functionality of the API remain unchanged—only the domain name is affected.

https://dev.netatmo.com/apidocumentation/weather